### PR TITLE
Fix Bukkit tab completion for trailing empty args

### DIFF
--- a/platform-bukkit/src/main/java/cn/monshine/commandlibrary/bukkit/BukkitCommandBridge.kt
+++ b/platform-bukkit/src/main/java/cn/monshine/commandlibrary/bukkit/BukkitCommandBridge.kt
@@ -14,7 +14,6 @@ class BukkitCommandBridge(
     }
 
     override fun tabComplete(sender: CommandSender, alias: String, args: Array<out String>): MutableList<String> {
-        return completer(sender, alias, args.filter { it.isNotEmpty() }).toMutableList()
+        return completer(sender, alias, args.toList()).toMutableList()
     }
 }
-


### PR DESCRIPTION
## Summary
- Preserve trailing empty arguments during Bukkit tab completion
- Keep execution behavior unchanged by only changing tabComplete argument handling

## Why
Bukkit passes an empty string for a trailing argument, such as when completing . Filtering empty arguments makes the command manager treat the input as if no argument is being completed, so it may suggest the root label instead of parameter completions.

## Test
- mvn -pl platform-bukkit -am test
- mvn -pl platform-bukkit -am -DskipTests install